### PR TITLE
Add trim_output option to archive.extracted.

### DIFF
--- a/jira-servicedesk/confluence.sls
+++ b/jira-servicedesk/confluence.sls
@@ -19,6 +19,7 @@ unpack-confluence-tarball:
     - skip_verify: true
     - user: confluence
     - options: z
+    - trim_output: true
     - if_missing: {{ confluence.prefix }}/atlassian-confluence-{{ confluence.version }}
     - keep: True
     - require:
@@ -90,6 +91,7 @@ confluence-unpack-mysql-tarball:
     - archive_format: tar
     - user: confluence
     - options: z
+    - trim_output: true
     - if_missing: {{ confluence.prefix }}/confluence/confluence/WEB-INF/lib/mysql-connector-java-{{ confluence.mysql_connector_version }}-bin.jar
     - keep: True
 

--- a/jira-servicedesk/init.sls
+++ b/jira-servicedesk/init.sls
@@ -30,6 +30,7 @@ unpack-jira-tarball:
     - skip_verify: true
     - user: jira
     - options: z
+    - trim_output: true
     {% if jira.app_name == 'atlassian-servicedesk' %}
     - if_missing: {{ jira.prefix }}/atlassian-jira-servicedesk-{{ jira.version }}-standalone
     {% elif jira.app_name == 'jira' %}
@@ -71,6 +72,7 @@ unpack-mysql-tarball:
     - archive_format: tar
     - user: jira
     - options: z
+    - trim_output: true
     - if_missing: {{ jira.prefix }}/jira/lib/mysql-connector-java-{{ jira.mysql_connector_version }}-bin.jar
     - keep: True
 


### PR DESCRIPTION
Otherwise the output is big and ci job fails with: Job's log exceeded limit of 4194304 bytes.

@marek-knappe FYI